### PR TITLE
Add support for low-precision Linear layers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,10 @@
 __pycache__
+benchmarks
+
 torchinductor*
+*.egg-info
+
+*.ptx
+*.png
+*.csv
+*.md

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # BasedXL: Accelerated Stable Diffusion XL with Patch Parallelism
 
-BasedXL is a demo project that showcases the implementation of Patch Parallelism from the [DistriFusion paper](https://arxiv.org/abs/2402.19481) to speed up multi-GPU performance of Stable Diffusion XL with minimal quality degradation. This project is intended to be run locally and is not a full library.
+BasedXL is a demo project that showcases an implementation of Patch Parallelism from the [DistriFusion paper](https://arxiv.org/abs/2402.19481) to speed up multi-GPU performance of Stable Diffusion XL with minimal quality degradation. This project is intended to be run locally and is not a full library.
 
 ## Features
 
@@ -32,7 +32,7 @@ python sample.py
 ### Compile
 Optionally compile the UNet with torch.compile for a slight speedup. (warning: can take minute or two)
 ```bash
-torchrun --nproc-per-node=2 sample.py --compile
+torchrun --nproc-per-node=2 sample.py --compile_unet
 ```
 
 

--- a/basedxl/modules/lowp_linear.py
+++ b/basedxl/modules/lowp_linear.py
@@ -1,0 +1,20 @@
+import torch
+import torch.nn as nn
+
+from basedxl.triton.cascaded_lowp_matmul import cascaded_lowp_matmul
+
+
+class BasedXLLowPLinear(nn.Module):
+    def __init__(self, submodule: nn.Linear):
+        super().__init__()
+        self.in_features = submodule.in_features
+        self.out_features = submodule.out_features
+        self.weight = submodule.weight.T.contiguous().clone()
+        self.bias = submodule.bias.clone() if submodule.bias is not None else None
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        x = cascaded_lowp_matmul(x, self.weight)
+        # TODO: Remove when we add bias support to the kernel
+        if self.bias is not None:
+            x = x + self.bias
+        return x

--- a/basedxl/triton/cascaded_lowp_matmul.py
+++ b/basedxl/triton/cascaded_lowp_matmul.py
@@ -1,0 +1,242 @@
+from typing import Optional
+
+import torch
+import triton
+import triton.language as tl
+
+
+K_ACC_DIV_MIN = 1
+K_ACC_DIV_MAX = 1
+
+VALUES_BLOCK_M = [256]
+VALUES_BLOCK_N = [128]
+VALUES_BLOCK_K = [16, 32]
+VALUES_GROUP_M = [8]
+VALUES_NUM_STAGES = [4]
+VALUES_NUM_WARPS = [8]
+
+M_MIN, N_MIN = 512, 256
+assert M_MIN >= min(VALUES_BLOCK_M)
+assert N_MIN >= min(VALUES_BLOCK_N)
+
+
+def calculate_k_acc_div(args: dict) -> int:
+    K, BLOCK_K = args["K"], args["BLOCK_K"]
+    ret = triton.next_power_of_2(int((K // BLOCK_K) ** 0.5))
+    return min(max(ret, K_ACC_DIV_MIN), K_ACC_DIV_MAX)
+
+
+@triton.autotune(
+    configs=[
+        *[
+            triton.Config(
+                {
+                    "BLOCK_M": BLOCK_M,
+                    "BLOCK_N": BLOCK_N,
+                    "BLOCK_K": BLOCK_K,
+                    "GROUP_M": GROUP_M,
+                },
+                num_stages=num_stages,
+                num_warps=num_warps,
+            )
+            for BLOCK_M in VALUES_BLOCK_M
+            for BLOCK_N in VALUES_BLOCK_N
+            for BLOCK_K in VALUES_BLOCK_K
+            for GROUP_M in VALUES_GROUP_M
+            for num_stages in VALUES_NUM_STAGES
+            for num_warps in VALUES_NUM_WARPS
+        ],
+    ],
+    key=["M", "N", "K"],
+)
+@triton.heuristics({"K_ACC_DIV": calculate_k_acc_div})
+@triton.heuristics({"K_IS_DIVISIBLE": lambda args: args["K"] % (args["BLOCK_K"] * args["K_ACC_DIV"]) == 0})
+@triton.jit
+def _matmul_kernel(
+    a_ptr,
+    b_ptr,
+    c_ptr,
+    M,
+    N,
+    K,
+    stride_am,
+    stride_ak,
+    stride_bk,
+    stride_bn,
+    stride_cm,
+    stride_cn,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+    BLOCK_K: tl.constexpr,
+    GROUP_M: tl.constexpr,
+    K_ACC_DIV: tl.constexpr,
+    K_IS_DIVISIBLE: tl.constexpr,
+):
+    """Kernel for computing the matmul C = A x B.
+    A has shape (M, K), B has shape (K, N) and C has shape (M, N)
+    """
+    pid = tl.program_id(axis=0)
+    num_pid_m = tl.cdiv(M, BLOCK_M)
+    num_pid_n = tl.cdiv(N, BLOCK_N)
+    num_pid_in_group = GROUP_M * num_pid_n
+    group_id = pid // num_pid_in_group
+    first_pid_m = group_id * GROUP_M
+    GROUP_M = min(num_pid_m - first_pid_m, GROUP_M)  # type: ignore
+    pid_m = first_pid_m + (pid % GROUP_M)
+    pid_n = (pid % num_pid_in_group) // GROUP_M
+
+    a_block_ptr = tl.make_block_ptr(
+        base=a_ptr,
+        shape=(M, K),
+        strides=(stride_am, stride_ak),
+        offsets=(pid_m * BLOCK_M, 0),
+        block_shape=(BLOCK_M, BLOCK_K),
+        order=(1, 0),
+    )
+
+    b_block_ptr = tl.make_block_ptr(
+        base=b_ptr,
+        shape=(K, N),
+        strides=(stride_bk, stride_bn),
+        offsets=(0, pid_n * BLOCK_N),
+        block_shape=(BLOCK_K, BLOCK_N),
+        order=(1, 0),
+    )
+
+    out = tl.zeros((BLOCK_M, BLOCK_N), dtype=tl.float32)
+    k_inner = tl.cdiv(K, BLOCK_K) // K_ACC_DIV
+
+    for k_i in range(0, K_ACC_DIV):
+        accumulator = tl.zeros((BLOCK_M, BLOCK_N), dtype=tl.float16)
+        for k in range(0, k_inner):
+            if K_IS_DIVISIBLE:
+                a = tl.load(a_block_ptr)
+                b = tl.load(b_block_ptr)
+            else:
+                a = tl.load(a_block_ptr, boundary_check=(0, 1))
+                b = tl.load(b_block_ptr, boundary_check=(1, 0))
+
+            accumulator = tl.dot(a, b, acc=accumulator, out_dtype=tl.float16)
+
+            a_block_ptr = tl.advance(a_block_ptr, (0, BLOCK_K))
+            b_block_ptr = tl.advance(b_block_ptr, (BLOCK_K, 0))
+
+        out += accumulator.to(tl.float32)
+
+    out = out.to(tl.float16)
+
+    c_block_ptr = tl.make_block_ptr(
+        base=c_ptr,
+        shape=(M, N),
+        strides=(stride_cm, stride_cn),
+        offsets=(pid_m * BLOCK_M, pid_n * BLOCK_N),
+        block_shape=(BLOCK_M, BLOCK_N),
+        order=(1, 0),
+    )
+    tl.store(c_block_ptr, out, boundary_check=(0, 1))
+
+
+def cascaded_lowp_matmul(
+    a: torch.Tensor,
+    b: torch.Tensor,
+    *,
+    out: Optional[torch.Tensor] = None,
+    dump_ptx: bool = False,
+) -> torch.Tensor:
+    assert a.shape[-1] == b.shape[-2], "Incompatible dimensions"
+    # assert a.is_contiguous(), "Matrix A must be contiguous"
+    assert b.is_contiguous(), "Matrix B must be contiguous"
+
+    batch_dims, K = a.shape[:-1], a.shape[-1]
+    M = batch_dims.numel()
+    N = b.shape[-1]
+
+    # Dimension is smaller than the minimum block size, fallback to torch.matmul
+    if M < M_MIN or N < N_MIN:
+        return torch.matmul(a, b, out=out)
+
+    a = a.reshape(M, K).contiguous()
+
+    if out is None:
+        out = torch.empty((M, N), device=a.device, dtype=a.dtype)
+
+    def grid(meta: dict):
+        return (triton.cdiv(M, meta["BLOCK_M"]) * triton.cdiv(N, meta["BLOCK_N"]),)
+
+    kernel = _matmul_kernel[grid](
+        a, b, out, M, N, K, a.stride(0), a.stride(1), b.stride(0), b.stride(1), out.stride(0), out.stride(1)
+    )
+
+    if dump_ptx:
+        open("dump.ptx", "w").write(kernel.asm["ptx"])
+
+    return out.reshape(*batch_dims, N)
+
+
+if __name__ == "__main__":
+    import torch.nn.functional as F
+
+    torch.manual_seed(0)
+    a = torch.randn((4096, 14336), device="cuda", dtype=torch.float16)
+    b = torch.randn((14336, 4096), device="cuda", dtype=torch.float16)
+    triton_output = cascaded_lowp_matmul(a, b, dump_ptx=True)
+    torch_output = torch.matmul(a, b)
+
+    print(f"triton_output\n{triton_output[:2, :2]}")
+    print(f"torch_output\n{torch_output[:2, :2]}")
+
+    print("-" * 80)
+
+    target, d = torch_output, triton_output
+    l1, l2 = F.l1_loss(target, d), F.mse_loss(target, d)
+    max_err = (target - d).abs().max()
+    mean_rel_err = (target - d).abs().div(target.abs()).mean()
+    print(f"\tL1 error: {l1.item():.3f}")
+    print(f"\tL2 error: {l2.item():.3f}")
+    print(f"\tMax error: {max_err.item():.3f}")
+    print(f"\tMean relative error: {mean_rel_err.item():.3f}")
+
+    if torch.allclose(triton_output, torch_output, atol=1e-2, rtol=0):
+        print("✅ Triton and Torch match")
+    else:
+        print("❌ Triton and Torch differ")
+
+    @triton.testing.perf_report(
+        triton.testing.Benchmark(
+            x_names=["M", "N", "K"],  # Argument names to use as an x-axis for the plot
+            x_vals=[256 * i for i in range(1, 33)],  # Different possible values for `x_name`
+            # x_vals=[4096, 6144, 8192],
+            line_arg="provider",  # Argument name whose value corresponds to a different line in the plot
+            # Possible values for `line_arg`
+            line_vals=["cublas", "triton"],
+            # Label name for the lines
+            line_names=["cuBLAS (fp32 acc)", "Triton (fp16 acc, cascaded)"],
+            # Line styles
+            styles=[("green", "-"), ("blue", "-")],
+            ylabel="TFLOP/s",  # Label name for the y-axis
+            plot_name="matmul-performance",  # Name for the plot, used also as a file name for saving the plot.
+            args={},
+        )
+    )
+    def benchmark(M, N, K, provider):
+        a = torch.randn((M, K), device="cuda", dtype=torch.float16)
+        b = torch.randn((K, N), device="cuda", dtype=torch.float16)
+
+        kwargs = dict(
+            quantiles=[0.5, 0.1, 0.9],
+            return_mode="min",
+        )
+
+        if provider == "cublas":
+            ms, min_ms, max_ms = triton.testing.do_bench(lambda: torch.matmul(a, b), **kwargs)
+        elif provider == "triton":
+            ms, min_ms, max_ms = triton.testing.do_bench(lambda: cascaded_lowp_matmul(a, b), **kwargs)
+        else:
+            raise
+
+        def perf(ms: float) -> float:
+            return 2 * M * N * K * 1e-12 / (ms * 1e-3)
+
+        return perf(ms), perf(max_ms), perf(min_ms)
+
+    benchmark.run(save_path="benchmarks/triton/cascaded_lowp_matmul", print_data=True)

--- a/basedxl/utils.py
+++ b/basedxl/utils.py
@@ -9,6 +9,8 @@ from torch._C._distributed_c10d import Work, ProcessGroup  # type: ignore
 class BasedXLConfig:
     pretrained_model_name_or_path: str = "stabilityai/stable-diffusion-xl-base-1.0"
     dtype: torch.dtype = torch.float16
+    fp16_acc_matmul: bool = False
+    patch_parallelism: bool = False
     compile_unet: bool = False
     width: int = 1024
     height: int = 1024

--- a/basedxl/utils.py
+++ b/basedxl/utils.py
@@ -1,7 +1,7 @@
 from dataclasses import dataclass
 
 import torch
-from torch import distributed as dist
+import torch.distributed as dist
 from torch._C._distributed_c10d import Work, ProcessGroup  # type: ignore
 
 
@@ -25,6 +25,7 @@ class BasedXLConfig:
             self.rank = dist.get_rank()
             self.world_size = dist.get_world_size()
             self.device = f"cuda:{self.rank}"
+            torch.cuda.set_device(self.rank)
         except Exception:
             print("Failed to initialize distributed process group. Running in single-device mode.")
             self.rank = 0

--- a/extras/measure_cascaded_lowp_matmul_error.py
+++ b/extras/measure_cascaded_lowp_matmul_error.py
@@ -1,0 +1,49 @@
+import pandas as pd
+import torch
+import torch.nn.functional as F
+import numpy as np
+from basedxl.triton.cascaded_lowp_matmul import cascaded_lowp_matmul
+
+DUMP_TABLE: bool = True
+EPS: float = 1e-6
+QUANTILES: list[float] = [0.01, 0.2, 0.5, 0.8, 0.99]
+
+rows = []
+for M, N, K in [
+    (4096, 4096, 4096),
+    (4096, 14336, 4096),
+    (14336, 4096, 4096),
+    (4096, 4096, 14336),
+]:
+    torch.manual_seed(42)
+    A = torch.randn(M, K, device="cuda", dtype=torch.float16)
+    B = torch.randn(K, N, device="cuda", dtype=torch.float16)
+    expected = A.double() @ B.double()
+
+    lowp_out = cascaded_lowp_matmul(A, B)
+    base_out = A @ B
+
+    for acc_type, out in [("fp32", base_out), ("fp16", lowp_out)]:
+        l1, mse = F.l1_loss(expected, out), F.mse_loss(expected, out)
+        max_err = (expected - out).abs().max()
+        rel_err = (expected - out).abs().div(expected.abs() + EPS)
+        rel_err_cpu = rel_err.to("cpu", torch.float64).numpy()
+        rel_err_quantiles = np.quantile(rel_err_cpu, QUANTILES)
+
+        print(M, K, N, "-" * 20, acc_type, "acc", "-" * 20)
+        print(f"\tL1 error: {l1.item():.3f}")
+        print(f"\tMSE error: {mse.item():.3f}")
+        print(f"\tMax error: {max_err.item():.3f}")
+        print(f"\t          PERCENTILES: {' '.join(f'{q:10}' for q in QUANTILES)}")
+        print(f"\t       relative error: {' '.join(f'{q:10.7f}' for q in rel_err_quantiles)}")
+
+    if DUMP_TABLE:
+        rows.append([M, K, N, l1.item(), mse.item(), max_err.item(), rel_err.median().item()])
+
+
+if DUMP_TABLE:
+    df = pd.DataFrame(rows, columns=["M", "K", "N", "L1", "MSE", "Max", "Median rel"])
+    print("-" * 80)
+    print(df)
+    df.to_csv("results.csv", index=False)
+    df.to_markdown("results.md", index=False)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,9 @@ license = { text = "MIT License" }
 requires-python = ">= 3.10"
 dependencies = ["torch>=2.2", "diffusers>=0.26"]
 
+[tool.setuptools]
+packages = ["basedxl"]
+
 [tool.black]
 line-length = 120
 

--- a/sample.py
+++ b/sample.py
@@ -26,6 +26,8 @@ def main(
     width: int = 1024,
     height: int = 1024,
     compile: bool = False,
+    fp16_acc_matmul: bool = False,
+    patch_parallelism: bool = False,
     distrifusion_warmup_steps: int = 4,
     out_path: str = "sample.png",
     verbose: bool = False,
@@ -34,6 +36,8 @@ def main(
         width=width,
         height=height,
         compile_unet=compile,
+        fp16_acc_matmul=fp16_acc_matmul,
+        patch_parallelism=patch_parallelism,
         warmup_steps=distrifusion_warmup_steps,
         verbose=verbose,
     )

--- a/sample.py
+++ b/sample.py
@@ -51,7 +51,12 @@ def main(
     )
 
     # Warmup
-    pipeline(prompt=prompt, negative_prompt=negative_prompt, guidance_scale=guidance_scale)
+    pipeline(
+        prompt=prompt,
+        negative_prompt=negative_prompt,
+        guidance_scale=guidance_scale,
+        num_inference_steps=10,
+    )
 
     # Generate
     torch.cuda.cudart().cudaProfilerStart()  # type: ignore

--- a/sample.py
+++ b/sample.py
@@ -25,17 +25,19 @@ def main(
     num_inference_steps: int = 50,
     width: int = 1024,
     height: int = 1024,
-    compile: bool = False,
+    compile_unet: bool = False,
     fp16_acc_matmul: bool = False,
-    patch_parallelism: bool = False,
+    patch_parallelism: bool = True,
     distrifusion_warmup_steps: int = 4,
     out_path: str = "sample.png",
     verbose: bool = False,
 ):
+    assert not (compile_unet and fp16_acc_matmul), "torch.compile currently breaks on user defined triton kernels."
+
     basedxl_config = BasedXLConfig(
         width=width,
         height=height,
-        compile_unet=compile,
+        compile_unet=compile_unet,
         fp16_acc_matmul=fp16_acc_matmul,
         patch_parallelism=patch_parallelism,
         warmup_steps=distrifusion_warmup_steps,

--- a/tests/test_cascaded_lowp_matmul.py
+++ b/tests/test_cascaded_lowp_matmul.py
@@ -1,0 +1,26 @@
+import torch
+import pytest
+from basedxl.triton.cascaded_lowp_matmul import cascaded_lowp_matmul
+
+
+@pytest.mark.parametrize(
+    "shape_a, shape_b",
+    [
+        ((10, 20), (20, 30)),  # Non-batched matrices
+        ((5, 10, 20), (20, 30)),  # First matrix is batched
+        ((10, 20), (5, 20, 30)),  # Second matrix is batched
+        ((5, 10, 20), (5, 20, 30)),  # Both matrices are batched
+        [(128, 512), (512, 128)],
+        [(1024, 2048), (2048, 1024)],
+        # TODO: Failing because the criteria is static and too strict.
+        # Need to do the math and find the correct expected threshold.
+        # [(4096, 8192), (8192, 4096)],
+        # [(4096, 14336), (14336, 4096)], # Mistral-7B MLP worst case (~0.8 max abs error)
+    ],
+)
+def test_cascaded_lowp_matmul(shape_a, shape_b):
+    a = torch.randn(*shape_a, device="cuda", dtype=torch.float16)
+    b = torch.randn(*shape_b, device="cuda", dtype=torch.float16)
+    output = cascaded_lowp_matmul(a, b)
+    expected = torch.matmul(a, b)
+    assert torch.allclose(output, expected, rtol=0.001, atol=0.35)


### PR DESCRIPTION
Consumer graphics cards like the RTX 4090 have their performance (artificially) halved for tensor core matmuls where the accumulator is float32. PyTorch does currently not provide a way to change the accumulator precision passed to cuBLAS, hence why this PR adds support for this feature via a triton kernel. 

Performance difference:

| Layer type       | Linear layer accumulator precision | Throughput | K_ACC_DIV_MAX |
|------------------|------------------------------------|------------|---------------|
| nn.Linear        | fp32                               | 8.25 it/s  | N/A
| BasedXLLowPLinear| fp16 (cascaded)                    | 8.75 it/s  | 32
| BasedXLLowPLinear| fp16 (cascaded)                    | 9.15 it/s  | 4
| BasedXLLowPLinear| fp16                               | 9.75 it/s  | 1